### PR TITLE
Fix DiscoridanDateTime

### DIFF
--- a/foomodules/Commands.py
+++ b/foomodules/Commands.py
@@ -545,6 +545,7 @@ class DiscordianDateTime:
         "Zaraday",
         "Bureflux",
         "Maladay",
+        "Afflux",
     ]
 
     SEASONS = [


### PR DESCRIPTION
Add missing holiday name "Afflux", the current code generates a IndexError on transforming a date on the Afflux holiday.
